### PR TITLE
Add Cloudflare Turnstile alongside reCAPTCHA in shadow mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -123,7 +123,7 @@ function App({ __linkUrl = "" }: SettingsData) {
 
       await loadScript("https://embed.laylo.com/linktree/laylo.js");
       loadedLaylo.current = true;
-      await Promise.all([
+      await Promise.allSettled([
         loadScript(
           "https://www.google.com/recaptcha/api.js?render=6LfaRWApAAAAAPvWsG2tsIhBCLEdXyz_EUQtQily"
         ),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -116,11 +116,21 @@ function App({ __linkUrl = "" }: SettingsData) {
 
   useEffect(() => {
     const loadScripts = async () => {
+      // Must be set BEFORE laylo.js loads — the embed reads __CAPTCHA_PROVIDER__ at init.
+      // "shadow" runs reCAPTCHA + Turnstile in parallel; reCAPTCHA token is used,
+      // Turnstile is logged for metrics. Matches laylo-drop-page production setting.
+      (window as any).__CAPTCHA_PROVIDER__ = "shadow";
+
       await loadScript("https://embed.laylo.com/linktree/laylo.js");
       loadedLaylo.current = true;
-      await loadScript(
-        "https://www.google.com/recaptcha/api.js?render=6LfaRWApAAAAAPvWsG2tsIhBCLEdXyz_EUQtQily"
-      );
+      await Promise.all([
+        loadScript(
+          "https://www.google.com/recaptcha/api.js?render=6LfaRWApAAAAAPvWsG2tsIhBCLEdXyz_EUQtQily"
+        ),
+        loadScript(
+          "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+        ),
+      ]);
 
       const style = document.createElement("style");
       style.innerHTML = ".grecaptcha-badge { display: none; }";


### PR DESCRIPTION
## Summary
- Set `window.__CAPTCHA_PROVIDER__ = "shadow"` **before** loading `embed.laylo.com/linktree/laylo.js` so `@laylo/drop` picks up the provider config at init.
- Load Cloudflare Turnstile's challenge script (`https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit`) in parallel with the existing reCAPTCHA v3 script.

## Why
`laylo-drop-page` already runs in `"shadow"` mode on production — both providers fire, reCAPTCHA tokens remain authoritative, Turnstile is logged for metrics. linktree-app is the only Laylo host still on reCAPTCHA-only, which blocks the embed's Turnstile code path from collecting data here. This makes linktree-app match drop-page so the Turnstile rollout signal is consistent across surfaces.

## How it works
- The sitekey is **not** in the script URL — `?render=explicit` is a Turnstile rendering mode, not a key. The actual sitekey (`0x4AAAAAADArTK4hvCot7A2u`) is baked into `@laylo/drop` and passed to `turnstile.render(...)` by the embed.
- No backend changes — the existing `verify-verify-*` Lambda already parses the `recaptcha:X,turnstile:Y` shadow-mode token string that `@laylo/drop` sends.
- Requires `embed.laylo.com/linktree/laylo.js` to be built from a `laylo-drop` revision that has `getCaptchaToken.ts` (origin/main does).

## Test Plan
- [ ] Deploy preview, open a linktree page, confirm both `recaptcha/api.js` and `turnstile/v0/api.js` load in Network tab.
- [ ] Confirm `window.__CAPTCHA_PROVIDER__ === "shadow"` in DevTools console before the embed mounts.
- [ ] Trigger an RSVP on the embed; in the console, confirm `[captcha …]` logs from `@laylo/drop` show both `recaptcha=yes` and `turnstile=yes/EMPTY` for shadow mode.
- [ ] Confirm the RSVP still succeeds end-to-end (reCAPTCHA token continues to be the authoritative one verified server-side).
- [ ] Confirm the `.grecaptcha-badge` style is still hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a second third-party CAPTCHA script and changes initialization order for the Laylo embed; failures or timing differences could impact RSVP/embed flows, though the change is localized to client-side script loading.
> 
> **Overview**
> Configures the Laylo embed to run CAPTCHA in **shadow** mode by setting `window.__CAPTCHA_PROVIDER__ = "shadow"` *before* loading `embed.laylo.com/linktree/laylo.js`.
> 
> Updates script loading to fetch Cloudflare Turnstile (`turnstile/v0/api.js?render=explicit`) in parallel with the existing reCAPTCHA v3 script via `Promise.allSettled`, keeping the reCAPTCHA badge-hiding style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d61f0191bfcdaabbba68e2fb24a354c3592957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->